### PR TITLE
fire VanityReserved event & fix checks for transfers

### DIFF
--- a/Vanity.sol
+++ b/Vanity.sol
@@ -192,6 +192,7 @@ contract VanityURL is Ownable,Pausable {
     require(tokenAddress.doTransfer(msg.sender,transferTokenTo,reservePricing));
     vanity_address_mapping[_vanity_url] = msg.sender;
     address_vanity_mapping[msg.sender] = _vanity_url;
+    VanityReserved(msg.sender, _vanity_url);
   }
 
   /*
@@ -247,16 +248,19 @@ contract VanityURL is Ownable,Pausable {
     require(reservedKeywords[_vanity_url] != 1);
     vanity_address_mapping[_vanity_url] = msg.sender;
     address_vanity_mapping[msg.sender] = _vanity_url;
+    VanityReserved(msg.sender, _vanity_url);
   }
 
   /*
   function to transfer ownership for Vanity URL
   */
   function transferOwnershipForVanityURL(address _to) whenNotPaused public {
-    require(bytes(address_vanity_mapping[_to]).length != 0);
+    require(bytes(address_vanity_mapping[_to]).length == 0);
+    require(bytes(address_vanity_mapping[msg.sender]).length != 0);
     address_vanity_mapping[_to] = address_vanity_mapping[msg.sender];
     vanity_address_mapping[address_vanity_mapping[msg.sender]] = _to;
     delete(address_vanity_mapping[msg.sender]);
+    VanityReserved(_to, address_vanity_mapping[msg.sender]);
   }
 
   /*

--- a/Vanity.sol
+++ b/Vanity.sol
@@ -259,8 +259,8 @@ contract VanityURL is Ownable,Pausable {
     require(bytes(address_vanity_mapping[msg.sender]).length != 0);
     address_vanity_mapping[_to] = address_vanity_mapping[msg.sender];
     vanity_address_mapping[address_vanity_mapping[msg.sender]] = _to;
-    delete(address_vanity_mapping[msg.sender]);
     VanityReserved(_to, address_vanity_mapping[msg.sender]);
+    delete(address_vanity_mapping[msg.sender]);
   }
 
   /*


### PR DESCRIPTION
1. Events were not being fired

2. Transfer function was  incorrectly checking for receiver not having a vanity URL. Also added check for sender to have a non-empty vanity url.